### PR TITLE
Marked ResolveUrlTokenFilter as final. Also..

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,5 +79,10 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.6.6</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/sia/ch6/BitlyExampleResolver.java
+++ b/src/main/java/sia/ch6/BitlyExampleResolver.java
@@ -1,0 +1,14 @@
+package sia.ch6;
+
+public class BitlyExampleResolver implements UrlResolver {
+    public String expand(String shortenedUrl) {
+        // TODO: implement a real way to resolve shortened URLs
+        if ("http://bit.ly/3ynriE".equals(shortenedUrl)) {
+            return "lucene.apache.org/solr";
+        } else if ("http://bit.ly/15tzw".equals(shortenedUrl)) {
+            return "manning.com";
+        } else {
+            return shortenedUrl;
+        }
+    }
+}

--- a/src/main/java/sia/ch6/ResolveUrlTokenFilter.java
+++ b/src/main/java/sia/ch6/ResolveUrlTokenFilter.java
@@ -7,14 +7,16 @@ import org.apache.lucene.analysis.TokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 
-public class ResolveUrlTokenFilter extends TokenFilter {
+final public class ResolveUrlTokenFilter extends TokenFilter {
 
     private final CharTermAttribute termAttribute = addAttribute(CharTermAttribute.class);
     private final Pattern patternToMatchShortenedUrls;
+    private final UrlResolver urlResolver;
 
-    public ResolveUrlTokenFilter(TokenStream in, Pattern patternToMatchShortenedUrls) {
+    public ResolveUrlTokenFilter(TokenStream in, Pattern patternToMatchShortenedUrls, UrlResolver urlResolver) {
         super(in);
         this.patternToMatchShortenedUrls = patternToMatchShortenedUrls;
+        this.urlResolver = urlResolver;
     }
 
     @Override
@@ -35,18 +37,6 @@ public class ResolveUrlTokenFilter extends TokenFilter {
     }
 
     private String resolveShortenedUrl(String toResolve) {
-        try {
-            // TODO: implement a real way to resolve shortened URLs
-            if ("http://bit.ly/3ynriE".equals(toResolve)) {
-                return "lucene.apache.org/solr";
-            } else if ("http://bit.ly/15tzw".equals(toResolve)) {
-                return "manning.com";
-            }
-        } catch (Exception exc) {
-            // rather than failing analysis if you can't resolve the URL,
-            // you should log the error and return the un-resolved value
-            exc.printStackTrace();
-        }
-        return toResolve;
+        return urlResolver.expand(toResolve);
     }
 }

--- a/src/main/java/sia/ch6/ResolveUrlTokenFilterFactory.java
+++ b/src/main/java/sia/ch6/ResolveUrlTokenFilterFactory.java
@@ -8,8 +8,9 @@ import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.util.TokenFilterFactory;
 
 public class ResolveUrlTokenFilterFactory extends TokenFilterFactory {
-    
-    protected Pattern patternToMatchShortenedUrls;
+
+    private UrlResolver urlResolver;
+    private Pattern patternToMatchShortenedUrls;
     
     public ResolveUrlTokenFilterFactory(Map<String,String> args) {
         super(args);
@@ -17,10 +18,27 @@ public class ResolveUrlTokenFilterFactory extends TokenFilterFactory {
         assureMatchVersion();
         String shortenedUrlPattern = require(args, "shortenedUrlPattern");        
         patternToMatchShortenedUrls = Pattern.compile(shortenedUrlPattern);
+        determineUrlResolver(args);
+    }
+
+    private void determineUrlResolver(Map<String, String> args) {
+        try {
+            urlResolver = (UrlResolver) Class.forName(args.get("urlResolver")).newInstance();
+        } catch (ClassNotFoundException e) {
+            urlResolver = getDefaultUrlResolver();
+        } catch (InstantiationException e) {
+            urlResolver = getDefaultUrlResolver();
+        } catch (IllegalAccessException e) {
+            urlResolver = getDefaultUrlResolver();
+        }
+    }
+
+    private UrlResolver getDefaultUrlResolver() {
+        return new BitlyExampleResolver();
     }
     
     @Override
     public TokenFilter create(TokenStream input) {
-        return new ResolveUrlTokenFilter(input, patternToMatchShortenedUrls);
+        return new ResolveUrlTokenFilter(input, patternToMatchShortenedUrls, urlResolver);
     }
 }

--- a/src/main/java/sia/ch6/UrlResolver.java
+++ b/src/main/java/sia/ch6/UrlResolver.java
@@ -1,0 +1,7 @@
+package sia.ch6;
+
+public interface UrlResolver {
+
+    String expand(String shortenedUrl);
+
+}

--- a/src/test/java/sia/ch6/ResolveUrlTokenFilterTest.java
+++ b/src/test/java/sia/ch6/ResolveUrlTokenFilterTest.java
@@ -1,0 +1,40 @@
+package sia.ch6;
+
+import junit.framework.TestCase;
+import org.apache.lucene.analysis.TokenFilter;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.util.Version;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.*;
+
+public class ResolveUrlTokenFilterTest extends TestCase {
+
+    @Test
+    public void testResolveUrl() throws IOException {
+        Map<String, String> args = new HashMap<String, String>();
+        args.put("shortenedUrlPattern", "http:\\/\\/bit.ly/[\\w\\-]+");
+        args.put("luceneMatchVersion", Version.LUCENE_47.toString());
+        args.put("urlResolver", "sia.ch6.BitlyExampleResolver");
+        ResolveUrlTokenFilterFactory factory = new ResolveUrlTokenFilterFactory(args);
+
+        String string = "checkout: http://bit.ly/3ynriE";
+        StringReader reader = new StringReader(string);
+        WhitespaceTokenizer tokenizer = new WhitespaceTokenizer(Version.LUCENE_47, reader);
+        TokenFilter tokenFilter = factory.create(tokenizer);
+        CharTermAttribute attribute = tokenFilter.getAttribute(CharTermAttribute.class);
+        tokenFilter.reset();
+        List<String> actual = new ArrayList<String>();
+        while (tokenFilter.incrementToken()) {
+            actual.add(attribute.toString());
+        }
+        List<String> expected = Arrays.asList("checkout:", "lucene.apache.org/solr");
+        assertEquals(expected, actual);
+        tokenFilter.end();
+        tokenFilter.close();
+    }
+
+}


### PR DESCRIPTION
Additionally, I added a UrlResolver interface that can be defined as parameter to externalize url resolution logic. This logic is demonstrated in a unit test as well. SOLR is very new to me. I'm not sure if defining the class as a parameter is a silly idea. If it is, I wouldn't mind reverting those changes. 

IMHO, the only necessary change is marking the custom TokenFilter implementation as final.
